### PR TITLE
Add tqdm to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
             'h5py',
             'polars==0.14.*', # latest version,0.13 has some breaking APIs
             'sqlglot',
-            'graphviz'
+            'graphviz',
+            'tqdm'
             ], # add any additional packages that 
         license='http://www.apache.org/licenses/LICENSE-2.0',
         keywords=['python'],


### PR DESCRIPTION
`tqdm` is used within `quokka_runtime.py` as an inline import. Should be added as  required dependency.