### PR TITLE
Staged execution

### DIFF
--- a/apps/tpc-h/tpch.py
+++ b/apps/tpc-h/tpch.py
@@ -18,7 +18,7 @@ if mode == "DISK":
     cluster = LocalCluster()
 elif mode == "S3":
     manager = QuokkaClusterManager()
-    cluster = manager.get_cluster_from_json("new.json")
+    cluster = manager.get_cluster_from_json("config.json")
 else:
     raise Exception
 
@@ -170,7 +170,7 @@ def do_5():
     d = d.with_column("revenue", lambda x: x["l_extendedprice"] * ( 1 - x["l_discount"]) , required_columns={"l_extendedprice", "l_discount"})
     #f = d.groupby("n_name", orderby=[("revenue",'desc')]).agg({"revenue":["sum"]})
     f = d.groupby("n_name").agg({"revenue":["sum"]})
-
+    f.explain()
     return f.collect()
 
 # def do_5():
@@ -382,14 +382,14 @@ def sort():
 # print(do_3())
 
 # print(do_4())
-# print(do_5())
+print(do_5())
 # print(do_6())
 # print(do_7())
 # print(do_8())
 # print(do_9())
 # print(do_12())
 
-print(do_12_alternate())
+# print(do_12_alternate())
 
 # print(word_count())
 # print(covariance())

--- a/pyquokka/core.py
+++ b/pyquokka/core.py
@@ -97,6 +97,7 @@ class TaskManager:
         self.FOT = FunctionObjectTable()
         self.SAT = SortedActorsTable()
         self.PFT = PartitionFunctionTable()
+        self.AST = ActorStageTable()
 
         # populate this dictionary from the initial assignment 
             
@@ -190,7 +191,7 @@ class TaskManager:
     def register_blocking(self, actor_id, transform_fn, dataset_object):
         self.blocking_nodes[actor_id] = (transform_fn, dataset_object)
         return True
-    
+
     def check_in_recovery(self):
         if self.r.get("recovery-lock") == b'1':
             print("Recovery request detected, I am going to wait ", self.node_id)
@@ -449,17 +450,20 @@ class ExecTaskManager(TaskManager):
         count = -1
         self.index = 0
         self.sat = self.SAT.to_dict(self.r)
+        self.ast = self.AST.to_dict(self.r)
 
         while True:
 
             self.check_in_recovery()
+            self.current_stage = int(self.r.get("current-execution-stage"))
 
             count += 1
-            length = self.NTT.llen(self.r, str(self.node_id))
-            if length == 0:
-                continue
 
             candidate_tasks = self.NTT.lrange(self.r, str(self.node_id), 0, -1)
+            candidate_tasks = [candidate_task for candidate_task in candidate_tasks if self.ast[pickle.loads(candidate_task)[1][0]] <= self.current_stage]
+            length = len(candidate_tasks)
+            if length == 0:
+                continue
             # exec_tape_task = False
             # for candidate_task in candidate_tasks:
             #     task_type, tup = pickle.loads(candidate_task)
@@ -607,6 +611,7 @@ class ExecTaskManager(TaskManager):
 
                     out_seq = self.process_output(actor_id, channel_id, output, transaction, state_seq, out_seq)
                     if out_seq == -1:
+                        # this aborts the transaction automatically
                         continue
                         
                     next_task = ExecutorTask(actor_id, channel_id, state_seq + 1, out_seq, new_input_reqs)
@@ -619,7 +624,7 @@ class ExecTaskManager(TaskManager):
                         continue
                     last_output_seq = out_seq - 1
                     # print("DONE", actor_id, channel_id)
-                    self.DST.set(self.r, pickle.dumps((actor_id, channel_id)), last_output_seq)
+                    self.DST.set(transaction, pickle.dumps((actor_id, channel_id)), last_output_seq)
                             
                     next_task = None
 
@@ -795,7 +800,7 @@ class IOTaskManager(TaskManager):
         Let's start with having one functionObject object for each channel.
         This might need to duplicated data etc. future optimization.
         """
-    
+        self.ast = self.AST.to_dict(self.r)
         pyarrow.set_cpu_count(8)
         count = -1
         while True:
@@ -803,13 +808,15 @@ class IOTaskManager(TaskManager):
             if self.delay - 0.1 > 0.1:
                 self.delay -= 0.1
             self.check_in_recovery()
+            self.current_stage = int(self.r.get("current-execution-stage"))
 
             count += 1
-            length = self.NTT.llen(self.r, str(self.node_id))
-            if length == 0:
-                continue 
 
             candidate_tasks = self.NTT.lrange(self.r, str(self.node_id), 0, -1)
+            candidate_tasks = [candidate_task for candidate_task in candidate_tasks if self.ast[pickle.loads(candidate_task)[1][0]] <= self.current_stage]
+            if len(candidate_tasks) == 0:
+                continue
+            
             candidate_task = random.sample(candidate_tasks,1 )[0]
             task_type, tup = pickle.loads(candidate_task)
 
@@ -829,10 +836,6 @@ class IOTaskManager(TaskManager):
                 next_task, output, seq, lineage = candidate_task.execute(functionObject)
 
                 print_if_profile("read time", time.time() - start)
-
-                if next_task is None:
-                    # print("DONE", actor_id, channel_id)
-                    self.DST.set(self.r, pickle.dumps((actor_id, channel_id)), seq)
             
             elif task_type == "inputtape":
                 candidate_task = TapedInputTask.from_tuple(tup)
@@ -862,6 +865,9 @@ class IOTaskManager(TaskManager):
                 transaction = self.r.pipeline()
                 self.output_commit(transaction, actor_id, channel_id, seq, lineage)
                 self.task_commit(transaction, candidate_task, next_task)
+                if next_task is None:
+                    # print("DONE", actor_id, channel_id)
+                    self.DST.set(transaction, pickle.dumps((actor_id, channel_id)), seq)
                 if not all(transaction.execute()):
                    print("COMMITING TRANSACTION FAILED")
                    # raise Exception
@@ -908,6 +914,7 @@ class ReplayTaskManager(TaskManager):
         count = -1
         while True:
             self.check_in_recovery()
+            # you don't need to check your execution stage since replay tasks can happen whenever.
 
             count += 1
             length = self.NTT.llen(self.r, str(self.node_id))

--- a/pyquokka/datastream.py
+++ b/pyquokka/datastream.py
@@ -857,7 +857,7 @@ class DataStream:
                     sources={0: self, 1: right},
                     partitioners={0: HashPartitioner(
                         left_on), 1: HashPartitioner(right_on)},
-                    node=StatefulNode(
+                    node=JoinNode(
                         schema=new_schema,
                         schema_mapping=schema_mapping,
                         required_columns={0: {left_on}, 1: {right_on}},
@@ -873,7 +873,7 @@ class DataStream:
                     sources={0: self, 1: right},
                     partitioners={0: HashPartitioner(
                         left_on), 1: HashPartitioner(right_on)},
-                    node=StatefulNode(
+                    node=JoinNode(
                         schema=new_schema,
                         schema_mapping=schema_mapping,
                         required_columns={0: {left_on}, 1: {right_on}},
@@ -889,7 +889,7 @@ class DataStream:
                     sources={0: right, 1: self},
                     partitioners={0: HashPartitioner(
                         right_on), 1: HashPartitioner(left_on)},
-                    node=StatefulNode(
+                    node=JoinNode(
                         schema=new_schema,
                         schema_mapping=schema_mapping,
                         required_columns={0: {right_on}, 1: {left_on}},

--- a/pyquokka/executors.py
+++ b/pyquokka/executors.py
@@ -619,11 +619,10 @@ class BuildProbeJoinExecutor(Executor):
 class JoinExecutor(Executor):
     # batch func here expects a list of dfs. This is a quark of the fact that join results could be a list of dfs.
     # batch func must return a list of dfs too
-    def __init__(self, on = None, left_on = None, right_on = None, suffix="_right", how = "inner"):
+    def __init__(self, on = None, left_on = None, right_on = None, how = "inner"):
 
         self.state0 = None
         self.state1 = None
-        self.suffix = suffix
 
         if on is not None:
             assert left_on is None and right_on is None
@@ -709,9 +708,9 @@ class JoinExecutor(Executor):
 
         if stream_id == 0:
             if self.state1 is not None:
-                result = batch.join(self.state1,left_on = self.left_on, right_on = self.right_on ,how=self.batch_how, suffix=self.suffix)
+                result = batch.join(self.state1,left_on = self.left_on, right_on = self.right_on ,how=self.batch_how)
                 if self.how == "left" or self.how == "semi":
-                    new_left_null = batch.join(self.state1, left_on = self.left_on, right_on= self.right_on, how = "anti", suffix = self.suffix)
+                    new_left_null = batch.join(self.state1, left_on = self.left_on, right_on= self.right_on, how = "anti")
             else:
                 if self.how == "left" or self.how == "semi":
                     new_left_null = batch
@@ -731,13 +730,13 @@ class JoinExecutor(Executor):
         elif stream_id == 1:
 
             if self.state0 is not None and self.how != "semi":
-                result = self.state0.join(batch,left_on = self.left_on, right_on = self.right_on ,how=self.batch_how, suffix=self.suffix)
+                result = self.state0.join(batch,left_on = self.left_on, right_on = self.right_on ,how=self.batch_how)
                 
             if self.how == "semi" and self.left_null is not None:
-                result = self.left_null.join(batch, left_on = self.left_on, right_on = self.right_on, how = "semi", suffix = self.suffix)
+                result = self.left_null.join(batch, left_on = self.left_on, right_on = self.right_on, how = "semi")
             
             if (self.how == "left" or self.how == "semi") and self.left_null is not None:
-                self.left_null = self.left_null.join(batch, left_on = self.left_on, right_on = self.right_on, how = "anti", suffix = self.suffix)
+                self.left_null = self.left_null.join(batch, left_on = self.left_on, right_on = self.right_on, how = "anti")
 
             if self.state1 is None:
                 if self.how == "left":
@@ -746,8 +745,6 @@ class JoinExecutor(Executor):
             else:
                 self.state1.vstack(batch, in_place = True)
         
-        
-
         if result is not None and len(result) > 0:
             return result
     
@@ -767,7 +764,7 @@ class JoinExecutor(Executor):
         #print("done join ", executor_id)
         if self.how == "left" and self.left_null is not None and len(self.left_null) > 0:
             assert self.first_row_right is not None, "empty RHS"
-            return self.left_null.join(self.first_row_right, left_on= self.left_on, right_on= self.right_on, how = "left", suffix = self.suffix)
+            return self.left_null.join(self.first_row_right, left_on= self.left_on, right_on= self.right_on, how = "left")
 
         # print("DONE", executor_id)
 

--- a/pyquokka/logical.py
+++ b/pyquokka/logical.py
@@ -88,6 +88,9 @@ class Node:
         # this will be a dictionary of 
         self.output_sorted_reqs = None
     
+    def assign_stage(self, stage):
+        self.stage = stage
+    
     def lower(self, task_graph):
         raise NotImplementedError
 
@@ -98,7 +101,7 @@ class Node:
         self.placement_strategy = strategy
     
     def __str__(self):
-        result = str(type(self)) + '\nParents:' + str(self.parents) + '\nTargets:' 
+        result = str(type(self)) + '\n' + str(self.stage) + '\nParents:' + str(self.parents) + '\nTargets:' 
         for target in self.targets:
             result += "\n\t" + str(target) + " " + textwrap.fill(str(self.targets[target]))
         return result
@@ -108,7 +111,7 @@ class SourceNode(Node):
         super().__init__(schema)
     
     def __str__(self):
-        result = str(type(self)) + '\nTargets:' 
+        result = str(type(self)) + '\n' + str(self.stage) + '\nTargets:' 
         for target in self.targets:
             result += "\n\t" + str(target) + " " + str(self.targets[target])
         return result
@@ -267,7 +270,7 @@ class JoinNode(TaskNode):
         self.join_specs.append(join_spec)
     
     def __str__(self):
-        result = 'Join Node with joins: ' + str(self.join_specs) + '\nParents:' + str(self.parents) + '\nTargets:' 
+        result = 'Join Node with joins: ' + str(self.join_specs) + '\n' + str(self.stage) + '\nParents:' + str(self.parents) + '\nTargets:' 
         for target in self.targets:
             result += "\n\t" + str(target) + " " + textwrap.fill(str(self.targets[target]))
         return result
@@ -280,10 +283,25 @@ class JoinNode(TaskNode):
             transform_func = target_info_to_transform_func(target_info)
         
         print("lowering join node with ", len(self.join_specs), " join specs. Random join order used right now.")
-        # import pdb;pdb.set_trace()
         joined_parents = set()
 
-        for i in range(len(self.join_specs)):
+        # self.join_specs = [self.join_specs[1]] + [self.join_specs[0]]
+
+        join_spec = self.join_specs[0]
+        join_type, join_keys = join_spec
+        assert len(join_keys) == 2
+        left = list(join_keys.keys())[0]
+        right = list(join_keys.keys())[1]
+        operator = JoinExecutor(None, join_keys[left], join_keys[right], join_type)
+        left_parent_target_info = parent_source_info[left]
+        right_parent_target_info = parent_source_info[right]
+        left_parent_target_info.partitioner = HashPartitioner(join_keys[left])
+        right_parent_target_info.partitioner = HashPartitioner(join_keys[right])
+        intermediate_node = task_graph.new_non_blocking_node({0: parent_nodes[left], 1: parent_nodes[right]}, operator, self.placement_strategy, source_target_info={0: left_parent_target_info, 1: right_parent_target_info})
+        joined_parents.add(parent_nodes[left])
+        joined_parents.add(parent_nodes[right])
+
+        for i in range(1, len(self.join_specs)):
             join_spec = self.join_specs[i]
             join_type, join_keys = join_spec
             assert len(join_keys) == 2
@@ -297,17 +315,19 @@ class JoinNode(TaskNode):
             elif parent_nodes[left] in joined_parents:
                 intermediate_target_info = TargetInfo(HashPartitioner(join_keys[left]), sqlglot.exp.TRUE, None, [])
                 parent_target_info = parent_source_info[right]
+                parent_target_info.partitioner = HashPartitioner(join_keys[right])
+                # print("adding node", intermediate_node, parent_nodes[right], {0: str(intermediate_target_info), 1: str(parent_target_info)})
                 intermediate_node = task_graph.new_non_blocking_node({0: intermediate_node, 1: parent_nodes[right]}, operator, self.placement_strategy, source_target_info={0: intermediate_target_info, 1: parent_target_info})
                 joined_parents.add(parent_nodes[right])
             elif parent_nodes[right] in joined_parents:
                 intermediate_target_info = TargetInfo(HashPartitioner(join_keys[right]), sqlglot.exp.TRUE, None, [])
                 parent_target_info = parent_source_info[left]
+                parent_target_info.partitioner = HashPartitioner(join_keys[left])
+                # print("adding node", parent_nodes[left], intermediate_node, {0: str(parent_target_info), 1: str(intermediate_target_info)})
                 intermediate_node = task_graph.new_non_blocking_node({0: parent_nodes[left], 1: intermediate_node}, operator, self.placement_strategy, source_target_info={0: parent_target_info, 1: intermediate_target_info})
                 joined_parents.add(parent_nodes[left])
             else:
-                intermediate_node = task_graph.new_non_blocking_node({0: parent_nodes[left], 1: parent_nodes[right]}, operator, self.placement_strategy, source_target_info={0: parent_source_info[left], 1: parent_source_info[right]})
-                joined_parents.add(parent_nodes[left])
-                joined_parents.add(parent_nodes[right])
+                raise Exception("Should not happen")
         
         return intermediate_node
 

--- a/pyquokka/logical.py
+++ b/pyquokka/logical.py
@@ -268,7 +268,16 @@ class StatefulNode(TaskNode):
             return task_graph.new_blocking_node(parent_nodes,self.operator, self.placement_strategy, source_target_info=parent_source_info, transform_fn = transform_func, assume_sorted = self.assume_sorted)
         else:
             return task_graph.new_non_blocking_node(parent_nodes,self.operator, self.placement_strategy, source_target_info=parent_source_info, assume_sorted = self.assume_sorted)
-        
+
+class JoinNode(StatefulNode):
+    def __init__(self, schema, schema_mapping, required_columns, operator, assume_sorted = {}) -> None:
+        super().__init__(schema, schema_mapping, required_columns, operator, assume_sorted)
+
+    def lower(self, task_graph, parent_nodes, parent_source_info):
+        if len(self.parents) > 2:
+            raise Exception("JoinNode can only have two parents! You didn't finish the join re-org in the optimization pass.")
+        return super().lower(task_graph, parent_nodes, parent_source_info)
+
 '''
 We need a separate MapNode from StatefulNode since we can compact UDFs
 

--- a/pyquokka/quokka_runtime.py
+++ b/pyquokka/quokka_runtime.py
@@ -233,6 +233,8 @@ class TaskGraph:
             target_info.lowered = True
 
             self.PFT.set(self.r, pickle.dumps((source, self.current_actor)), ray.cloudpickle.dumps(target_info))
+
+            # TODO: figure out why you need to do this to make it work
             self.PFT.get(self.r, pickle.dumps((source, self.current_actor)))
             
             registered = ray.get([node.register_partition_function.remote(source, self.current_actor, self.get_total_channels_from_placement_strategy(placement_strategy, 'exec')) for node in (self.nodes.values())])

--- a/pyquokka/tables.py
+++ b/pyquokka/tables.py
@@ -297,3 +297,16 @@ class PartitionFunctionTable(ClientWrapper):
         keys = self.keys(redis_client)
         values = self.mget(redis_client, keys)
         return {pickle.loads(key): value for key, value in zip(keys, values)}
+
+'''
+- Actor Stage Table (AST): this stores the stage of each actor
+'''
+
+class ActorStageTable(ClientWrapper):
+    def __init__(self) -> None:
+        super().__init__("AST")
+    
+    def to_dict(self, redis_client):
+        keys = self.keys(redis_client)
+        values = self.mget(redis_client, keys)
+        return {int(key): int(value) for key, value in zip(keys, values)}


### PR DESCRIPTION
This is a significant change in how we are doing things in Quokka.

Up to release 0.1.5 we are doing joins with streaming X join where both sides are built, now we choose one side to be build and block until that is done and then stream through the probe. This is more in line with traditional databases.

Might see performance degradations on joins in TPC-H, that's ok. Join order selection not implemented yet asof this PR. 