### PR TITLE
CMT: fix hash equality error

### DIFF
--- a/pyquokka/executors.py
+++ b/pyquokka/executors.py
@@ -101,7 +101,8 @@ class HoppingWindowExecutor(Executor):
         batch = polars.concat(batches)
 
         # current polars implementation cannot support floating point groupby dynamic and rolling operations.
-        assert (batch[self.time_col].dtype in {polars.Int32, polars.Int64, polars.Datetime, polars.Date} )
+        assert (batch[self.time_col].dtype == polars.Int32 or batch[self.time_col].dtype == polars.Int64 or 
+        batch[self.time_col].dtype == polars.Datetime or batch[self.time_col].dtype == polars.Date), batch[self.time_col].dtype
 
         size = self.window.size_polars
         hop = self.window.hop_polars            
@@ -237,7 +238,8 @@ class SlidingWindowExecutor(Executor):
         batch = polars.concat(batches)
 
         # current polars implementation cannot support floating point groupby dynamic and rolling operations.
-        assert (batch[self.time_col].dtype in {polars.Int32, polars.Int64, polars.Datetime, polars.Date} )
+        assert (batch[self.time_col].dtype == polars.Int32 or batch[self.time_col].dtype == polars.Int64 or 
+        batch[self.time_col].dtype == polars.Datetime or batch[self.time_col].dtype == polars.Date), batch[self.time_col].dtype
 
         size = self.window.size_before_polars
         to_discard = None
@@ -284,7 +286,8 @@ class SessionWindowExecutor(Executor):
         batch = polars.concat(batches)
 
         # current polars implementation cannot support floating point groupby dynamic and rolling operations.
-        assert (batch[self.time_col].dtype in {polars.Int32, polars.Int64, polars.Datetime, polars.Date} )
+        assert (batch[self.time_col].dtype == polars.Int32 or batch[self.time_col].dtype == polars.Int64 or 
+        batch[self.time_col].dtype == polars.Datetime or batch[self.time_col].dtype == polars.Date), batch[self.time_col].dtype
         timeout = self.window.timeout
 
         if self.state is not None:


### PR DESCRIPTION
Fixed the hashing equality error in the `executors.py` file. 

All instances of type assertion use "== or" syntax.