### PR TITLE
sql: change main function args, add example script

### DIFF
--- a/apps/tpc-h/tpch_sql.py
+++ b/apps/tpc-h/tpch_sql.py
@@ -1,0 +1,20 @@
+from pyquokka.sql import generate_code
+mode = 'DISK'
+format_ = 'parquet'
+
+query_no = 1
+query_path = '' + str(query_no) + '.sql'
+with open(query_path, 'r') as f:
+    query = f.read()
+data_path=""
+
+generate_code(query, data_path, table_prefixes = {
+        'l': 'lineitem',
+        'o': 'orders',
+        'c': 'customer',
+        'p': 'part',
+        'ps': 'partsupp',
+        's': 'supplier',
+        'r': 'region',
+        'n': 'nation'
+        }, mode=mode, format_=format_)


### PR DESCRIPTION
- Add example script to print out dataframe code generated from SQL query.
- Change the main function of sql.py to take in data path, mode, and data format to minimize extra work required. Only 'DISK' mode is supported for now.