### PR TITLE
sql: fix date formatting in filters, add comments

### DIFF
--- a/apps/tpc-h/tpch_sql.py
+++ b/apps/tpc-h/tpch_sql.py
@@ -3,10 +3,10 @@ mode = 'DISK'
 format_ = 'parquet'
 
 query_no = 1
-query_path = '' + str(query_no) + '.sql'
+query_path = '' + str(query_no) + '.sql' # TODO: update the first '' with a path to folder of queries
 with open(query_path, 'r') as f:
     query = f.read()
-data_path=""
+data_path="" # TODO: update this variable
 
 generate_code(query, data_path, table_prefixes = {
         'l': 'lineitem',


### PR DESCRIPTION
- Add instruction comments to TPCH from SQL example.
- Add more documentation to draft implementation of from_sql feature.
- DuckDB generated plans currently included filters with incorrect formatting which aren't valid sql, e.g. "l_shipdate<1994-01-01". This patch is only a temporary fix but fixes the date formatting using regexes.